### PR TITLE
Can't use a different Selenium Address for helper browsers

### DIFF
--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -142,6 +142,8 @@ export class Runner extends EventEmitter {
           ...config,
           capabilities: caps,
           helper: true,
+          seleniumAddress: caps.seleniumAddress || config.seleniumAddress,
+          directConnect: caps.directConnect || config.directConnect
         };
         this.driverprovider_.push(buildDriverProvider(cfg));
       }
@@ -216,6 +218,7 @@ export class Runner extends EventEmitter {
       this.o = o;
     };
   }
+
   installKeepAlive(
       browser: ProtractorBrowser,
       keepAlive: number|{trigger?: (browser: ProtractorBrowser) => void, seconds: number}): void {

--- a/package.json
+++ b/package.json
@@ -82,5 +82,5 @@
   "engines": {
     "node": ">=6.9.x"
   },
-  "version": "5.2.0-3"
+  "version": "5.2.0-4"
 }


### PR DESCRIPTION
Enable using multiple seleniumAddresses and directConnect configurations for helper browsers.

This is specially useful when using a mobile + web combination, as the former requires an Appium  server while the later requires a Selenium Server / Direct Connect.